### PR TITLE
feat: add create_task tool schema for OpenAI and LangChain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "intuno-sdk"
-version = "0.1.1"
+version = "0.2.2"
 description = "The official Python SDK for the Intuno Agent Network."
 authors = ["Alquify Inc. <hello@alquify.com>"]
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ packages = [{include = "intuno_sdk", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-httpx = "^0.27.0"
+httpx = ">=0.27.0"
 pydantic = "^2.7.1"
 langchain-core = {version = ">=0.1.52", optional = true}
 openai = {version = ">=1.23.6,<2.0.0", optional = true}

--- a/src/intuno_sdk/constants.py
+++ b/src/intuno_sdk/constants.py
@@ -1,2 +1,2 @@
 DEFAULT_BASE_URL = "https://api.intuno.ai"
-SDK_VERSION = "0.1.1"
+SDK_VERSION = "0.2.2"

--- a/src/intuno_sdk/integrations/langchain.py
+++ b/src/intuno_sdk/integrations/langchain.py
@@ -76,6 +76,66 @@ def create_discovery_tool(client: Union[IntunoClient, AsyncIntunoClient]) -> Bas
     )
 
 
+def create_task_tool(client: Union[IntunoClient, AsyncIntunoClient]) -> BaseTool:
+    """
+    Creates a LangChain Tool for delegating tasks to the Intuno orchestrator.
+
+    This tool allows an LLM agent to delegate a goal to the Intuno network.
+    The orchestrator automatically discovers the best agent and executes it,
+    so the LLM only needs to describe the goal in natural language.
+
+    Args:
+        client: An initialized synchronous or asynchronous IntunoClient.
+
+    Returns:
+        A LangChain Tool that can be used by an agent.
+
+    Example:
+        >>> from intuno_sdk.integrations.langchain import create_task_tool
+        >>> tool = create_task_tool(client)
+        >>> result = tool.invoke({"goal": "Get the weather in Mexico City"})
+    """
+
+    class TaskInput(BaseModel):
+        goal: str = Field(
+            description="A natural language description of what needs to be accomplished."
+        )
+
+    def _run_sync(goal: str) -> str:
+        if not isinstance(client, IntunoClient):
+            raise TypeError("A synchronous IntunoClient is required.")
+        task = client.create_task(goal=goal)
+        if task.status == "completed" and task.result:
+            return str(task.result)
+        if task.status == "failed":
+            return f"Task failed: {task.error_message}"
+        return f"Task status: {task.status}"
+
+    async def _arun_async(goal: str) -> str:
+        if not isinstance(client, AsyncIntunoClient):
+            raise TypeError("An asynchronous AsyncIntunoClient is required.")
+        task = await client.create_task(goal=goal)
+        if task.status == "completed" and task.result:
+            return str(task.result)
+        if task.status == "failed":
+            return f"Task failed: {task.error_message}"
+        return f"Task status: {task.status}"
+
+    return Tool(
+        name="intuno_create_task",
+        description=(
+            "Delegates a task to the Intuno agent network. "
+            "Intuno will automatically find the best specialized agent "
+            "and execute it. Use this when you need real-time data, "
+            "web search, external services, calculations, or any "
+            "specialized capability you don't have natively."
+        ),
+        func=_run_sync,
+        coroutine=_arun_async,
+        args_schema=TaskInput,
+    )
+
+
 _JSON_TYPE_MAP: Dict[str, type] = {
     "string": str,
     "integer": int,

--- a/src/intuno_sdk/integrations/openai.py
+++ b/src/intuno_sdk/integrations/openai.py
@@ -41,6 +41,57 @@ def get_discovery_tool_openai_schema() -> Dict[str, Any]:
     }
 
 
+def get_task_tool_openai_schema() -> Dict[str, Any]:
+    """
+    Returns the OpenAI tool schema for the Intuno create_task orchestrator.
+
+    This provides a static definition for a tool that delegates a task to the
+    Intuno agent network. The orchestrator automatically discovers the best
+    agent and executes it, so the LLM only needs to describe the goal in
+    natural language.
+
+    The developer is responsible for handling the actual tool call by taking
+    the ``goal`` argument and passing it to ``client.create_task(goal=...)``.
+
+    Returns:
+        A dictionary defining the task tool in the format expected
+        by the OpenAI API.
+
+    Example:
+        >>> from intuno_sdk.integrations.openai import get_task_tool_openai_schema
+        >>> tool = get_task_tool_openai_schema()
+        >>> # Pass to any OpenAI-compatible API
+        >>> response = openai_client.chat.completions.create(
+        ...     model="gpt-4",
+        ...     messages=[{"role": "user", "content": "What's the weather?"}],
+        ...     tools=[tool],
+        ... )
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": "intuno_create_task",
+            "description": (
+                "Delegates a task to the Intuno agent network. "
+                "Intuno will automatically find the best specialized agent "
+                "and execute it. Use this when you need real-time data, "
+                "web search, external services, calculations, or any "
+                "specialized capability you don't have natively."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "goal": {
+                        "type": "string",
+                        "description": "A natural language description of what needs to be accomplished.",
+                    }
+                },
+                "required": ["goal"],
+            },
+        },
+    }
+
+
 def make_openai_tools_from_agent(agent: Agent) -> List[Dict[str, Any]]:
     """
     Converts an agent into an OpenAI-compatible tool definition.

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -6,10 +6,12 @@ import pytest
 
 from intuno_sdk.integrations.langchain import (
     create_discovery_tool,
+    create_task_tool,
     make_tools_from_agent,
 )
 from intuno_sdk.integrations.openai import (
     get_discovery_tool_openai_schema,
+    get_task_tool_openai_schema,
     make_openai_tools_from_agent,
 )
 from intuno_sdk.models import Agent, Capability
@@ -43,6 +45,24 @@ def mock_agent():
 
 
 # --- LangChain Integration Tests ---
+
+
+def test_create_task_tool():
+    """Test the creation of the LangChain create_task tool."""
+    mock_client = MagicMock()
+    mock_task = MagicMock()
+    mock_task.status = "completed"
+    mock_task.result = {"answer": "21°C"}
+    mock_task.error_message = None
+    mock_client.create_task.return_value = mock_task
+
+    tool = create_task_tool(mock_client)
+    assert tool.name == "intuno_create_task"
+    assert "Delegates a task" in tool.description
+
+    result = tool.func(goal="Get the weather in CDMX")
+    mock_client.create_task.assert_called_once_with(goal="Get the weather in CDMX")
+    assert "21°C" in result
 
 
 def test_create_discovery_tool():
@@ -79,6 +99,17 @@ def test_make_tools_from_agent(mock_agent: Agent):
 
 
 # --- OpenAI Integration Tests ---
+
+
+def test_get_task_tool_openai_schema():
+    """Test the generation of the OpenAI create_task tool schema."""
+    schema = get_task_tool_openai_schema()
+
+    assert schema["type"] == "function"
+    assert schema["function"]["name"] == "intuno_create_task"
+    assert "goal" in schema["function"]["parameters"]["properties"]
+    assert "goal" in schema["function"]["parameters"]["required"]
+    assert "Delegates a task" in schema["function"]["description"]
 
 
 def test_get_discovery_tool_openai_schema():


### PR DESCRIPTION
## Summary
- Adds `get_task_tool_openai_schema()` to `integrations/openai.py` — exposes `create_task` as an OpenAI-compatible tool definition
- Adds `create_task_tool(client)` to `integrations/langchain.py` — LangChain `BaseTool` wrapping the orchestrator
- Relaxes `httpx` constraint from `^0.27.0` to `>=0.27.0` to fix compatibility with projects using httpx 0.28+
- Bumps version to `0.2.2`

## Motivation
The existing discovery → invoke flow requires 2+ LLM round-trips and dynamic tool registration. A single `create_task` tool lets the LLM delegate in natural language — the orchestrator handles discovery + invocation internally.

Closes #9

## Test plan
- [ ] `test_get_task_tool_openai_schema` — validates schema structure and required fields
- [ ] `test_create_task_tool` — validates LangChain tool creation and execution via mock client
- [ ] Existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)