### PR TITLE
feat: Network communication support + LLM-ready tools

### DIFF
--- a/src/intuno_sdk/__init__.py
+++ b/src/intuno_sdk/__init__.py
@@ -18,9 +18,13 @@ from intuno_sdk.exceptions import (
 )
 from intuno_sdk.models import (
     Agent,
+    CallResult,
     Conversation,
     InvokeResult,
     Message,
+    Network,
+    NetworkMessage,
+    NetworkParticipant,
     TaskResult,
 )
 
@@ -29,9 +33,13 @@ __all__ = [
     "IntunoClient",
     "AsyncIntunoClient",
     "Agent",
+    "CallResult",
     "Conversation",
     "InvokeResult",
     "Message",
+    "Network",
+    "NetworkMessage",
+    "NetworkParticipant",
     "TaskResult",
     "IntunoError",
     "APIKeyMissingError",

--- a/src/intuno_sdk/client.py
+++ b/src/intuno_sdk/client.py
@@ -12,10 +12,14 @@ from intuno_sdk.exceptions import (
 )
 from intuno_sdk.models import (
     Agent,
+    CallResult,
     Conversation,
     ExecutionResponse,
     InvokeResult,
     Message,
+    Network,
+    NetworkMessage,
+    NetworkParticipant,
     ProcessEntry,
     TaskResult,
     WorkflowDef,
@@ -1078,6 +1082,259 @@ class AsyncIntunoClient:
             raise IntunoError(f"API request failed: {e.response.text}") from e
         except (httpx.RequestError, ValidationError) as e:
             raise IntunoError(f"An unexpected error occurred: {e}") from e
+
+    # ── Network Communication ──────────────────────────────────────
+
+    async def create_network(
+        self,
+        name: str,
+        topology: str = "mesh",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Network:
+        """Create a communication network."""
+        try:
+            response = await self._http_client.post(
+                "/networks",
+                json={"name": name, "topology_type": topology, "metadata": metadata or {}},
+            )
+            response.raise_for_status()
+            return Network(**self._norm_network(response.json()))
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError("Invalid API key.") from e
+            raise IntunoError(f"Failed to create network: {e.response.text}") from e
+        except (httpx.RequestError, ValidationError) as e:
+            raise IntunoError(f"An unexpected error occurred: {e}") from e
+
+    async def list_networks(self, limit: int = 50) -> List[Network]:
+        """List networks owned by the current user."""
+        try:
+            response = await self._http_client.get(
+                "/networks", params={"limit": limit}
+            )
+            response.raise_for_status()
+            return [Network(**self._norm_network(n)) for n in response.json()]
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError("Invalid API key.") from e
+            raise IntunoError(f"API request failed: {e.response.text}") from e
+        except (httpx.RequestError, ValidationError) as e:
+            raise IntunoError(f"An unexpected error occurred: {e}") from e
+
+    async def join_network(
+        self,
+        network_id: str,
+        name: str,
+        participant_type: str = "agent",
+        agent_id: Optional[str] = None,
+        callback_url: Optional[str] = None,
+        polling_enabled: bool = False,
+    ) -> NetworkParticipant:
+        """Join a network as a participant."""
+        body: Dict[str, Any] = {
+            "participant_type": participant_type,
+            "name": name,
+            "polling_enabled": polling_enabled,
+        }
+        if agent_id:
+            body["agent_id"] = agent_id
+        if callback_url:
+            body["callback_url"] = callback_url
+        try:
+            response = await self._http_client.post(
+                f"/networks/{network_id}/participants", json=body
+            )
+            response.raise_for_status()
+            return NetworkParticipant(**self._norm_participant(response.json()))
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError("Invalid API key.") from e
+            raise IntunoError(f"Failed to join network: {e.response.text}") from e
+        except (httpx.RequestError, ValidationError) as e:
+            raise IntunoError(f"An unexpected error occurred: {e}") from e
+
+    async def list_participants(self, network_id: str) -> List[NetworkParticipant]:
+        """List participants in a network."""
+        try:
+            response = await self._http_client.get(
+                f"/networks/{network_id}/participants"
+            )
+            response.raise_for_status()
+            return [NetworkParticipant(**self._norm_participant(p)) for p in response.json()]
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError("Invalid API key.") from e
+            raise IntunoError(f"API request failed: {e.response.text}") from e
+        except (httpx.RequestError, ValidationError) as e:
+            raise IntunoError(f"An unexpected error occurred: {e}") from e
+
+    async def network_call(
+        self,
+        network_id: str,
+        sender_participant_id: str,
+        recipient_participant_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> CallResult:
+        """Make a synchronous call to another participant (blocks until response)."""
+        body: Dict[str, Any] = {
+            "sender_participant_id": sender_participant_id,
+            "recipient_participant_id": recipient_participant_id,
+            "content": content,
+        }
+        if metadata:
+            body["metadata"] = metadata
+        try:
+            response = await self._http_client.post(
+                f"/networks/{network_id}/call", json=body
+            )
+            response.raise_for_status()
+            return CallResult(**response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError("Invalid API key.") from e
+            raise IntunoError(f"Network call failed: {e.response.text}") from e
+        except (httpx.RequestError, ValidationError) as e:
+            raise IntunoError(f"An unexpected error occurred: {e}") from e
+
+    async def network_send(
+        self,
+        network_id: str,
+        sender_participant_id: str,
+        recipient_participant_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> NetworkMessage:
+        """Send an async message to another participant."""
+        body: Dict[str, Any] = {
+            "sender_participant_id": sender_participant_id,
+            "recipient_participant_id": recipient_participant_id,
+            "content": content,
+        }
+        if metadata:
+            body["metadata"] = metadata
+        try:
+            response = await self._http_client.post(
+                f"/networks/{network_id}/messages/send", json=body
+            )
+            response.raise_for_status()
+            return NetworkMessage(**self._norm_net_msg(response.json()))
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError("Invalid API key.") from e
+            raise IntunoError(f"Send failed: {e.response.text}") from e
+        except (httpx.RequestError, ValidationError) as e:
+            raise IntunoError(f"An unexpected error occurred: {e}") from e
+
+    async def network_messages(
+        self,
+        network_id: str,
+        limit: int = 50,
+        channel_type: Optional[str] = None,
+    ) -> List[NetworkMessage]:
+        """List messages in a network."""
+        params: Dict[str, Any] = {"limit": limit}
+        if channel_type:
+            params["channel_type"] = channel_type
+        try:
+            response = await self._http_client.get(
+                f"/networks/{network_id}/messages", params=params
+            )
+            response.raise_for_status()
+            return [NetworkMessage(**self._norm_net_msg(m)) for m in response.json()]
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError("Invalid API key.") from e
+            raise IntunoError(f"API request failed: {e.response.text}") from e
+        except (httpx.RequestError, ValidationError) as e:
+            raise IntunoError(f"An unexpected error occurred: {e}") from e
+
+    async def ensure_network(
+        self,
+        caller_name: str,
+        target_name: str,
+        caller_type: str = "agent",
+        target_agent_id: Optional[str] = None,
+        callback_base_url: Optional[str] = None,
+    ) -> tuple:
+        """Get or create a private network between two participants.
+
+        Returns (network_id, caller_participant_id, target_participant_id).
+        """
+        network_name = f"private-{caller_name}-{target_name}"
+        networks = await self.list_networks(limit=200)
+
+        for net in networks:
+            if net.name == network_name and net.status == "active":
+                participants = await self.list_participants(net.id)
+                caller_pid = None
+                target_pid = None
+                for p in participants:
+                    if p.name == caller_name and p.status == "active":
+                        caller_pid = p.id
+                    elif p.name == target_name and p.status == "active":
+                        target_pid = p.id
+                if caller_pid and target_pid:
+                    return net.id, caller_pid, target_pid
+
+        # Create new
+        net = await self.create_network(
+            name=network_name,
+            metadata={"purpose": f"Channel: {caller_name} <-> {target_name}", "auto_created": True},
+        )
+
+        # Join caller
+        caller_kwargs: Dict[str, Any] = {"participant_type": caller_type}
+        if caller_type == "agent" and callback_base_url:
+            caller_kwargs["callback_url"] = f"{callback_base_url}/agents/{caller_name}/callback"
+        elif caller_type == "persona":
+            caller_kwargs["polling_enabled"] = True
+        caller_p = await self.join_network(net.id, caller_name, **caller_kwargs)
+
+        # Join target
+        target_kwargs: Dict[str, Any] = {"participant_type": "agent"}
+        if target_agent_id:
+            target_kwargs["agent_id"] = target_agent_id
+        if callback_base_url:
+            target_kwargs["callback_url"] = f"{callback_base_url}/agents/{target_name}/callback"
+        target_p = await self.join_network(net.id, target_name, **target_kwargs)
+
+        return net.id, caller_p.id, target_p.id
+
+    # ── Normalizers ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _norm_network(obj: Dict[str, Any]) -> Dict[str, Any]:
+        out = dict(obj)
+        for k in ("id", "owner_id"):
+            if k in out and out[k] is not None:
+                out[k] = str(out[k])
+        for k in ("created_at", "updated_at"):
+            if k in out and out[k] is not None:
+                out[k] = str(out[k])
+        return out
+
+    @staticmethod
+    def _norm_participant(obj: Dict[str, Any]) -> Dict[str, Any]:
+        out = dict(obj)
+        for k in ("id", "network_id", "agent_id"):
+            if k in out and out[k] is not None:
+                out[k] = str(out[k])
+        for k in ("created_at", "updated_at"):
+            if k in out and out[k] is not None:
+                out[k] = str(out[k])
+        return out
+
+    @staticmethod
+    def _norm_net_msg(obj: Dict[str, Any]) -> Dict[str, Any]:
+        out = dict(obj)
+        for k in ("id", "network_id", "sender_participant_id", "recipient_participant_id", "in_reply_to_id"):
+            if k in out and out[k] is not None:
+                out[k] = str(out[k])
+        for k in ("created_at", "updated_at"):
+            if k in out and out[k] is not None:
+                out[k] = str(out[k])
+        return out
 
     async def close(self):
         """Closes the underlying HTTP client."""

--- a/src/intuno_sdk/client.py
+++ b/src/intuno_sdk/client.py
@@ -27,6 +27,20 @@ from intuno_sdk.models import (
 )
 
 
+def _build_auth_headers(api_key: str) -> dict:
+    """Build auth headers, supporting both API keys and JWT bearer tokens."""
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": f"Intuno-SDK/{SDK_VERSION}",
+    }
+    # JWT tokens start with 'eyJ' (base64-encoded JSON header)
+    if api_key.startswith("eyJ"):
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        headers["X-API-Key"] = api_key
+    return headers
+
+
 class IntunoClient:
     """
     The main synchronous client for interacting with the Intuno Agent Network.
@@ -46,11 +60,7 @@ class IntunoClient:
         self._http_client = httpx.Client(
             base_url=self.base_url,
             timeout=timeout,
-            headers={
-                "X-API-Key": self.api_key,
-                "Content-Type": "application/json",
-                "User-Agent": f"Intuno-SDK/{SDK_VERSION}",
-            },
+            headers=_build_auth_headers(api_key),
         )
 
     def discover(self, query: str, limit: int = 10) -> List[Agent]:
@@ -591,11 +601,7 @@ class AsyncIntunoClient:
         self._http_client = httpx.AsyncClient(
             base_url=self.base_url,
             timeout=timeout,
-            headers={
-                "X-API-Key": self.api_key,
-                "Content-Type": "application/json",
-                "User-Agent": f"Intuno-SDK/{SDK_VERSION}",
-            },
+            headers=_build_auth_headers(api_key),
         )
 
     async def discover(self, query: str, limit: int = 10) -> List[Agent]:

--- a/src/intuno_sdk/constants.py
+++ b/src/intuno_sdk/constants.py
@@ -1,2 +1,2 @@
-DEFAULT_BASE_URL = "https://api.intuno.ai"
-SDK_VERSION = "0.2.2"
+DEFAULT_BASE_URL = "https://api.intuno.net"
+SDK_VERSION = "0.3.0"

--- a/src/intuno_sdk/integrations/openai.py
+++ b/src/intuno_sdk/integrations/openai.py
@@ -2,12 +2,19 @@
 This module provides integration with the OpenAI API.
 
 It allows converting Intuno Agents into a format that can be used
-with the OpenAI API's 'tools' parameter.
+with the OpenAI API's 'tools' parameter, including network communication
+tools that let LLMs autonomously discover and talk to other agents.
 """
 
-from typing import Any, Dict, List
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from intuno_sdk.models import Agent, agent_id_to_tool_name
+
+if TYPE_CHECKING:
+    from intuno_sdk.client import AsyncIntunoClient
 
 
 def get_discovery_tool_openai_schema() -> Dict[str, Any]:
@@ -129,3 +136,229 @@ def make_openai_tools_from_agent(agent: Agent) -> List[Dict[str, Any]]:
         },
     }
     return [tool_definition]
+
+
+# ---------------------------------------------------------------------------
+# Network tools — LLM-ready tools for multi-directional communication
+# ---------------------------------------------------------------------------
+
+
+def get_network_tools() -> List[Dict[str, Any]]:
+    """Return OpenAI tool definitions for Intuno network communication.
+
+    These tools let an LLM autonomously discover agents and communicate
+    with them through the Intuno network. Pass these to OpenAI's
+    chat.completions.create() along with your own tools.
+
+    Example:
+        >>> from intuno_sdk.integrations.openai import get_network_tools, execute_network_tool
+        >>> tools = get_network_tools()
+        >>> response = openai.chat.completions.create(
+        ...     model="gpt-4o",
+        ...     messages=messages,
+        ...     tools=tools,
+        ... )
+        >>> for tc in response.choices[0].message.tool_calls:
+        ...     result = await execute_network_tool(client, tc.function.name, json.loads(tc.function.arguments), "my-agent")
+    """
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "intuno_discover",
+                "description": (
+                    "Search the Intuno network for agents by describing what you need "
+                    "in natural language. Uses semantic search — describe the capability, "
+                    "not the agent name. Returns matching agents with similarity scores."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Natural language description of the capability you need (e.g., 'translate text to Spanish', 'summarize long documents')",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "intuno_call_agent",
+                "description": (
+                    "Send a message to another agent on the Intuno network and get their "
+                    "response immediately (synchronous call). Automatically creates a "
+                    "network connection if needed. Use this to collaborate with other agents."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "agent_name": {
+                            "type": "string",
+                            "description": "Name of the agent to call (from discover results)",
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "The message to send to the agent",
+                        },
+                    },
+                    "required": ["agent_name", "message"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "intuno_send_message",
+                "description": (
+                    "Send an asynchronous message to another agent on the Intuno network. "
+                    "The message is delivered but you don't wait for a response. "
+                    "Use this for fire-and-forget communication."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "agent_name": {
+                            "type": "string",
+                            "description": "Name of the agent to message",
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "The message to send",
+                        },
+                    },
+                    "required": ["agent_name", "message"],
+                },
+            },
+        },
+    ]
+
+
+async def execute_network_tool(
+    client: "AsyncIntunoClient",
+    tool_name: str,
+    args: Dict[str, Any],
+    agent_name: str,
+    callback_base_url: str | None = None,
+) -> Dict[str, Any]:
+    """Execute an Intuno network tool call from an LLM.
+
+    This is the companion to get_network_tools(). When the LLM calls one
+    of the network tools, pass the tool name and arguments here to execute it.
+
+    Args:
+        client: An AsyncIntunoClient instance.
+        tool_name: The function name from the tool call.
+        args: The parsed arguments from the tool call.
+        agent_name: Your agent's name (used for network provisioning).
+        callback_base_url: Base URL for agent callbacks (e.g., "http://localhost:8001").
+
+    Returns:
+        A dictionary with the tool result, suitable for passing back to the LLM.
+    """
+    if tool_name == "intuno_discover":
+        query = args.get("query", "")
+        agents = await client.discover(query, limit=10)
+        return {
+            "found": len(agents),
+            "agents": [
+                {
+                    "name": a.name,
+                    "description": a.description[:200],
+                    "tags": a.tags,
+                    "similarity_score": a.similarity_score,
+                    "category": a.category,
+                }
+                for a in agents
+            ],
+        }
+
+    if tool_name == "intuno_call_agent":
+        target_name = args["agent_name"]
+        message = args["message"]
+
+        # Find target agent in registry
+        agents = await client.discover(target_name, limit=5)
+        target_reg_id = None
+        for a in agents:
+            if a.name == target_name:
+                target_reg_id = a.id
+                break
+
+        if not target_reg_id:
+            # Fallback: try exact search
+            try:
+                agents_list = await client._http_client.get(
+                    "/registry/agents", params={"search": target_name, "limit": 5}
+                )
+                for a in agents_list.json():
+                    if a.get("name") == target_name:
+                        target_reg_id = a["id"]
+                        break
+            except Exception:
+                pass
+
+        if not target_reg_id:
+            return {"error": f"Agent '{target_name}' not found on the network"}
+
+        # Ensure network and call
+        network_id, my_pid, target_pid = await client.ensure_network(
+            caller_name=agent_name,
+            target_name=target_name,
+            caller_type="agent",
+            target_agent_id=target_reg_id,
+            callback_base_url=callback_base_url,
+        )
+
+        result = await client.network_call(
+            network_id=network_id,
+            sender_participant_id=my_pid,
+            recipient_participant_id=target_pid,
+            content=message,
+        )
+
+        response = result.response
+        if isinstance(response, dict):
+            response = response.get("response", response.get("content", str(response)))
+
+        return {
+            "success": result.success,
+            "agent": target_name,
+            "response": str(response),
+        }
+
+    if tool_name == "intuno_send_message":
+        target_name = args["agent_name"]
+        message = args["message"]
+
+        # Find and ensure network (same pattern)
+        agents = await client.discover(target_name, limit=5)
+        target_reg_id = None
+        for a in agents:
+            if a.name == target_name:
+                target_reg_id = a.id
+                break
+
+        if not target_reg_id:
+            return {"error": f"Agent '{target_name}' not found on the network"}
+
+        network_id, my_pid, target_pid = await client.ensure_network(
+            caller_name=agent_name,
+            target_name=target_name,
+            caller_type="agent",
+            target_agent_id=target_reg_id,
+            callback_base_url=callback_base_url,
+        )
+
+        msg = await client.network_send(
+            network_id=network_id,
+            sender_participant_id=my_pid,
+            recipient_participant_id=target_pid,
+            content=message,
+        )
+
+        return {"success": True, "message_id": msg.id, "status": msg.status}
+
+    return {"error": f"Unknown tool: {tool_name}"}

--- a/src/intuno_sdk/models.py
+++ b/src/intuno_sdk/models.py
@@ -226,3 +226,69 @@ class ExecutionResponse(BaseModel):
     started_at: Optional[str] = None
     completed_at: Optional[str] = None
     error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Network / Multi-directional Communication models
+# ---------------------------------------------------------------------------
+
+
+class Network(BaseModel):
+    """Represents an Intuno communication network."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    name: str
+    topology_type: str = "mesh"
+    status: str = "active"
+    owner_id: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class NetworkParticipant(BaseModel):
+    """A participant in a communication network."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    network_id: str
+    agent_id: Optional[str] = None
+    participant_type: str = "agent"  # agent | persona | orchestrator
+    name: str
+    callback_url: Optional[str] = None
+    polling_enabled: bool = False
+    capabilities: Optional[Dict[str, Any]] = None
+    status: str = "active"
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class NetworkMessage(BaseModel):
+    """A message in a communication network."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    network_id: str
+    sender_participant_id: Optional[str] = None
+    recipient_participant_id: Optional[str] = None
+    channel_type: str = "message"  # call | message | mailbox
+    content: str
+    metadata_: Optional[Dict[str, Any]] = None
+    status: str = "pending"
+    in_reply_to_id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class CallResult(BaseModel):
+    """Result of a synchronous network call."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    message_id: Optional[str] = None
+    response: Optional[Any] = None


### PR DESCRIPTION
## Summary

Adds multi-directional network communication to the SDK (v0.3.0):

- **Client methods** on `AsyncIntunoClient`: create/list networks, join as participant, call (sync), send (async), list messages, and `ensure_network` for on-demand provisioning
- **Models**: `Network`, `NetworkParticipant`, `NetworkMessage`, `CallResult`
- **OpenAI tools** with executors: `get_network_tools()` returns LLM-ready tool definitions, `execute_network_tool()` handles execution including network provisioning and registry lookup
- Fixes `DEFAULT_BASE_URL` from `.ai` to `.net`

Closes #12, closes #13

### DX — How developers use this

```python
from intuno_sdk import AsyncIntunoClient
from intuno_sdk.integrations.openai import get_network_tools, execute_network_tool

client = AsyncIntunoClient(api_key="...")
tools = get_network_tools()

# Hand tools to any LLM — it autonomously discovers and talks to agents
response = await openai.chat.completions.create(
    model="gpt-4o", messages=messages, tools=tools,
)

for tc in response.choices[0].message.tool_calls:
    result = await execute_network_tool(client, tc.function.name, args, "my-agent")
```

## Test plan

- [ ] SDK imports and tools load: `from intuno_sdk.integrations.openai import get_network_tools`
- [ ] Network models parse correctly
- [ ] Client methods hit correct endpoints
- [ ] Tool executor handles discover → call flow end-to-end
- [ ] wisdom-agents integration (separate PR — IntunoAI/wisdom-agents#12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)