### PR TITLE
feat: Migrate Samantha to Claude, provider-configurable SmartAgent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "intuno-sdk"
-version = "0.2.2"
+version = "0.3.0"
 description = "The official Python SDK for the Intuno Agent Network."
 authors = ["Alquify Inc. <hello@alquify.com>"]
 license = "Apache-2.0"
@@ -24,6 +24,7 @@ pydantic = "^2.7.1"
 langchain-core = {version = ">=0.1.52", optional = true}
 openai = {version = ">=1.23.6,<2.0.0", optional = true}
 mcp = {version = ">=1.20", optional = true}
+anthropic = {version = ">=0.34.0", optional = true}
 
 [tool.poetry.scripts]
 intuno-mcp = "intuno_sdk.mcp_server:main"
@@ -32,6 +33,7 @@ intuno-mcp = "intuno_sdk.mcp_server:main"
 langchain = ["langchain-core"]
 openai = ["openai"]
 mcp = ["mcp"]
+anthropic = ["anthropic"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"

--- a/src/intuno_sdk/integrations/anthropic.py
+++ b/src/intuno_sdk/integrations/anthropic.py
@@ -1,0 +1,154 @@
+"""
+Anthropic (Claude) integration for the Intuno SDK.
+
+Provides tool schemas in the format expected by the Anthropic Messages API,
+network communication tools, and a utility for converting OpenAI-format
+tool definitions to Anthropic format.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from intuno_sdk.models import Agent, agent_id_to_tool_name
+
+from intuno_sdk.integrations.openai import execute_network_tool  # noqa: F401
+
+
+def openai_tool_to_anthropic(tool: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert an OpenAI-format tool definition to Anthropic format."""
+    fn = tool["function"]
+    return {
+        "name": fn["name"],
+        "description": fn.get("description", ""),
+        "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+    }
+
+
+def get_discovery_tool_anthropic_schema() -> Dict[str, Any]:
+    """Returns the Anthropic tool schema for Intuno agent discovery."""
+    return {
+        "name": "intuno_agent_discovery",
+        "description": (
+            "Searches the Intuno Agent Network to find agents with specific "
+            "capabilities. Use this when you need a new tool to solve a "
+            "user's request."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "A natural language description of the desired capability to search for.",
+                }
+            },
+            "required": ["query"],
+        },
+    }
+
+
+def get_task_tool_anthropic_schema() -> Dict[str, Any]:
+    """Returns the Anthropic tool schema for the Intuno create_task orchestrator."""
+    return {
+        "name": "intuno_create_task",
+        "description": (
+            "Delegates a task to the Intuno agent network. "
+            "Intuno will automatically find the best specialized agent "
+            "and execute it. Use this when you need real-time data, "
+            "web search, external services, calculations, or any "
+            "specialized capability you don't have natively."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "goal": {
+                    "type": "string",
+                    "description": "A natural language description of what needs to be accomplished.",
+                }
+            },
+            "required": ["goal"],
+        },
+    }
+
+
+def make_anthropic_tools_from_agent(agent: Agent) -> List[Dict[str, Any]]:
+    """Converts an Intuno Agent into an Anthropic-compatible tool definition."""
+    return [
+        {
+            "name": agent_id_to_tool_name(agent.agent_id),
+            "description": agent.description,
+            "input_schema": agent.input_schema or {"type": "object", "properties": {}},
+        }
+    ]
+
+
+def get_network_tools() -> List[Dict[str, Any]]:
+    """Return Anthropic tool definitions for Intuno network communication.
+
+    These tools let a Claude model autonomously discover agents and
+    communicate with them through the Intuno network.
+    """
+    return [
+        {
+            "name": "intuno_discover",
+            "description": (
+                "Search the Intuno network for agents by describing what you need "
+                "in natural language. Uses semantic search — describe the capability, "
+                "not the agent name. Returns matching agents with similarity scores."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural language description of the capability you need (e.g., 'translate text to Spanish', 'summarize long documents')",
+                    },
+                },
+                "required": ["query"],
+            },
+        },
+        {
+            "name": "intuno_call_agent",
+            "description": (
+                "Send a message to another agent on the Intuno network and get their "
+                "response immediately (synchronous call). Automatically creates a "
+                "network connection if needed. Use this to collaborate with other agents."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "agent_name": {
+                        "type": "string",
+                        "description": "Name of the agent to call (from discover results)",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "The message to send to the agent",
+                    },
+                },
+                "required": ["agent_name", "message"],
+            },
+        },
+        {
+            "name": "intuno_send_message",
+            "description": (
+                "Send an asynchronous message to another agent on the Intuno network. "
+                "The message is delivered but you don't wait for a response. "
+                "Use this for fire-and-forget communication."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "agent_name": {
+                        "type": "string",
+                        "description": "Name of the agent to message",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "The message to send",
+                    },
+                },
+                "required": ["agent_name", "message"],
+            },
+        },
+    ]


### PR DESCRIPTION
## Summary

- Make `SmartAgent` LLM provider-configurable via a `provider` class attribute (`"openai"` or `"anthropic"`, defaults to `"openai"`)
- Switch Samantha to Claude (`claude-sonnet-4-6` for conversations, `claude-haiku-4-5` for background tasks)
- Migrate consolidation (sleep cycle) and heartbeat (idle awareness) to Anthropic SDK
- Add `ANTHROPIC_API_KEY` to settings and `anthropic` to dependencies
- Existing agents (AssistantAgent, PublishedAgent) unchanged — they inherit `provider = "openai"`
- `appearance.py` stays on OpenAI/DALL-E for image generation

Closes #28
Related: #20 (ElevenLabs voice — depends on this for consistent Claude backend)

## Test plan

- [ ] Samantha responds to text messages via Claude (check logs for Anthropic API calls)
- [ ] Tool use works: remember, recall, intuno_discover, intuno_call_agent, visualize_self
- [ ] Consolidation cycle creates memories using Claude Haiku
- [ ] Heartbeat generates reflections and feelings using Claude Haiku
- [ ] Other agents (PublishedAgent) still work on OpenAI
- [ ] DALL-E image generation (visualize_self) still works via OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)